### PR TITLE
decode URI to work with text selection

### DIFF
--- a/js/qr.js
+++ b/js/qr.js
@@ -1,6 +1,6 @@
 var data = 'http://moin.im';
 if(window.location.hash) {
-	data = window.location.hash.replace('#','');
+	data = decodeURI(window.location.hash.replace('#',''));
 }
 $(function() {
 	$("#data").text(data);


### PR DESCRIPTION
Removes encoding like the following when selecting text.
`Extension%20code%20for%20Google%20Chrome%20and%20Opera's%20QR%20extensions.`